### PR TITLE
Fix proxyquire dependency injections

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,10 @@
 var proxyquire = require('proxyquire');
-module.exports = proxyquire('fs-extra', { 'ncp': require('graceful-ncp') });
+module.exports = proxyquire('fs-extra', {
+	'copy': proxyquire('fs-extra/lib/copy', {
+		'ncp': require('graceful-ncp')
+	}),
+	'move': proxyquire('fs-extra/lib/move', {
+		'ncp': require('graceful-ncp')
+	})
+});
+


### PR DESCRIPTION
This should fix mllrsohn/node-webkit-builder#204

The issue was that the `graceful-ncp` dependency injection didn't work at all, because `ncp` was required inside submodules of `fs-extra`.
This also does only work with `fs-extra` `v1.3.0`...
